### PR TITLE
Update spec-sync to v3.2.0 with hooks, requirements.md, and companion files

### DIFF
--- a/.github/workflows/spec-check.yml
+++ b/.github/workflows/spec-check.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: CorvidLabs/spec-sync@v3
+      - uses: CorvidLabs/spec-sync@v3.2.0
         with:
           strict: 'true'
           require-coverage: '100'

--- a/.github/workflows/spec-check.yml
+++ b/.github/workflows/spec-check.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: CorvidLabs/spec-sync@v2.4.0
+      - uses: CorvidLabs/spec-sync@v3
         with:
           strict: 'true'
           require-coverage: '100'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Spec-Sync Integration
+
+This project uses [spec-sync](https://github.com/CorvidLabs/spec-sync) for bidirectional spec-to-code validation.
+
+## Companion files
+
+Each spec in `specs/<module>/` has companion files — read them before working, update them after:
+
+- **`tasks.md`** — Work items for this module. Check off tasks (`- [x]`) as you complete them. Add new tasks if you discover work needed.
+- **`requirements.md`** — Acceptance criteria and user stories. These are permanent invariants, not tasks — do not check them off. Update if requirements change.
+- **`context.md`** — Architectural decisions, key files, and current status. Update when you make design decisions or change what's in progress.
+
+## Before modifying any module
+
+1. Read the relevant spec in `specs/<module>/<module>.spec.md`
+2. Read companion files: `tasks.md`, `requirements.md`, and `context.md`
+3. After changes, run `specsync check` to verify specs still pass
+
+## After completing work
+
+1. Mark completed items in `tasks.md` — check off finished tasks, add new ones discovered
+2. Update `context.md` — record decisions made, update current status
+3. If requirements changed, update `requirements.md` acceptance criteria
+
+## Before creating a PR
+
+Run `specsync check --strict` — all specs must pass with zero warnings.
+
+## When adding new modules
+
+Run `specsync add-spec <module-name>` to scaffold the spec and companion files, then fill in the spec before writing code.
+
+## Key commands
+
+- `specsync check` — validate all specs against source code
+- `specsync check --json` — machine-readable validation output
+- `specsync coverage` — show which modules lack specs
+- `specsync score` — quality score for each spec (0-100)
+- `specsync add-spec <name>` — scaffold a new spec with companion files
+- `specsync resolve --remote` — verify cross-project dependencies

--- a/specs/buffer/context.md
+++ b/specs/buffer/context.md
@@ -4,16 +4,22 @@ spec: buffer.spec.md
 
 ## Key Decisions
 
-<!-- Record architectural or design decisions relevant to this spec -->
+- Dual-backing strategy: files under 100 MB loaded as `Vec<u8>`, larger files use `memmap2::Mmap`. Abstracted via internal `Backing` enum.
+- Sparse edit overlay (`HashMap<usize, u8>`) — edits never modify the backing store directly, enabling cheap undo and non-destructive editing.
+- Self-cleaning edits: writing a byte that matches the original removes it from the overlay instead of storing a no-op.
+- Undo/redo via dual stacks of `UndoEntry { offset, previous_value }` — symmetric push/pop between stacks.
+- Chunked save for mmap files: reads 64 KB chunks, applies overlay edits, writes to temp file, then atomic rename.
 
 ## Files to Read First
 
-<!-- List the most important files an agent or new developer should read -->
+- `src/buffer.rs` — entire module implementation (open, get/set, undo/redo, save, find)
+- `src/lib.rs` — re-exports `Buffer`
 
 ## Current Status
 
-<!-- What's done, what's in progress, what's blocked -->
+Complete. All core functionality implemented and tested (30+ tests covering open, get/set, undo/redo, save, find, byte counting, edge cases).
 
 ## Notes
 
-<!-- Free-form notes, links, or context -->
+- `is_dirty` returns true if the overlay is non-empty, accurately reflecting unsaved state.
+- Find operations scan the full buffer (overlay-aware) — no indexing.

--- a/specs/buffer/requirements.md
+++ b/specs/buffer/requirements.md
@@ -1,0 +1,27 @@
+---
+spec: buffer.spec.md
+---
+
+## User Stories
+
+- As a user, I want to open binary files of any size so that I can inspect and edit them
+- As a user, I want edits to be non-destructive until I explicitly save so that I don't accidentally corrupt files
+- As a user, I want undo/redo support so that I can reverse mistakes while editing
+
+## Acceptance Criteria
+
+- Files under 100 MB are read fully into memory for fast random access
+- Files over 100 MB use memory-mapped I/O to avoid excessive memory usage
+- Edits are stored in a sparse overlay and only flushed on explicit save
+- Undo/redo stack tracks all byte modifications with correct offset tracking
+- `is_dirty` accurately reflects whether unsaved changes exist
+
+## Constraints
+
+- Must handle files up to several GB via mmap without loading into heap
+- Save operation must atomically flush all overlay edits to disk
+
+## Out of Scope
+
+- Concurrent file access / file locking
+- Network or remote file support

--- a/specs/chx/chx.spec.md
+++ b/specs/chx/chx.spec.md
@@ -45,6 +45,8 @@ Core application module for the `chx` hex editor. Defines the application state 
 | `StringKind` | `pub enum StringKind { Ascii, Utf8, Utf16Le, Utf16Be }` | Classification of an extracted string's encoding. |
 | `extract_strings` | `pub fn extract_strings(data: &[u8], min_length: usize) -> Vec<StringEntry>` | Scans binary data for ASCII, UTF-8, UTF-16 LE, and UTF-16 BE strings of at least `min_length` characters. Returns results sorted by offset. |
 | `export_strings` | `pub fn export_strings(entries: &[StringEntry], path: &Path) -> io::Result<()>` | Writes string entries to a text file in tab-separated format (`offset\tkind\ttext`). |
+| `redetect_template` | `pub fn redetect_template(&mut self)` | Re-runs format detection against the current buffer contents. Updates `active_template`, `template_fields`, and `template_field_map`. Called by the `:fmt detect` command. |
+| `template_field_info_at_cursor` | `pub fn template_field_info_at_cursor(&self) -> Option<String>` | Returns a description of the format template field at the cursor position for the status bar, or `None` if no field covers the cursor or the template overlay is hidden. |
 
 ## Invariants
 

--- a/specs/chx/requirements.md
+++ b/specs/chx/requirements.md
@@ -1,0 +1,27 @@
+---
+spec: chx.spec.md
+---
+
+## User Stories
+
+- As a user, I want a responsive terminal hex editor so that I can view and edit binary files from the command line
+- As a user, I want modal editing (normal, visual, edit, command, search) so that I can efficiently navigate and modify data
+- As a user, I want the editor to cleanly set up and tear down the terminal so that my shell is not corrupted on exit
+
+## Acceptance Criteria
+
+- Application starts in Normal mode with the file loaded and hex view rendered
+- Mode transitions are well-defined and all modes are reachable from Normal mode
+- Command mode supports save, quit, save-and-quit, goto, and search commands
+- Terminal is restored to its original state on both clean exit and panic
+- Event loop processes keyboard and mouse events without blocking
+
+## Constraints
+
+- Single-threaded event loop — must remain responsive under large files
+- Crossterm-based terminal handling for cross-platform support
+
+## Out of Scope
+
+- Multi-file / tabbed editing
+- Plugin or scripting system

--- a/specs/diff/context.md
+++ b/specs/diff/context.md
@@ -4,18 +4,21 @@ spec: diff.spec.md
 
 ## Key Decisions
 
-<!-- Record architectural or design decisions relevant to this spec -->
+- Pre-computed `diff_offsets: Vec<usize>` stores all differing byte indices at load time — binary-searched for O(log n) navigation.
+- Files of different lengths supported: bytes beyond the shorter file treated as differences.
+- Wrapping navigation: `next_diff()` and `prev_diff()` wrap at boundaries.
+- Viewport management (scroll offset, visible rows, cursor) decoupled from rendering.
+- Optional XOR view mode toggleable at runtime without recomputing diffs.
 
 ## Files to Read First
 
-- `src/diff.rs` — Core diff engine
+- `src/diff.rs` — `DiffState` struct, diff computation, navigation logic
 
 ## Current Status
 
-- Byte-by-byte diff comparison implemented
-- Navigation between diffs with wraparound working
-- Launched in v0.2.0
+Complete. Byte-by-byte comparison, wrapping navigation, XOR mode, and stats all implemented. Launched in v0.2.0.
 
 ## Notes
 
-<!-- Free-form notes, links, or context -->
+- Stats computed on-demand via `stats()` rather than cached.
+- 18 tests covering edge cases: empty files, different sizes, navigation wrapping.

--- a/specs/diff/context.md
+++ b/specs/diff/context.md
@@ -1,0 +1,21 @@
+---
+spec: diff.spec.md
+---
+
+## Key Decisions
+
+<!-- Record architectural or design decisions relevant to this spec -->
+
+## Files to Read First
+
+- `src/diff.rs` — Core diff engine
+
+## Current Status
+
+- Byte-by-byte diff comparison implemented
+- Navigation between diffs with wraparound working
+- Launched in v0.2.0
+
+## Notes
+
+<!-- Free-form notes, links, or context -->

--- a/specs/diff/diff.spec.md
+++ b/specs/diff/diff.spec.md
@@ -18,21 +18,21 @@ Provides byte-by-byte binary diff comparison between two files. Loads both files
 |--------|-----------|-------------|
 | `DiffState` | `pub struct DiffState` | Core state for a binary diff session. Public fields: `left_data: Vec<u8>`, `right_data: Vec<u8>`, `left_name: String`, `right_name: String`, `diff_offsets: Vec<usize>`, `diff_index: usize`, `cursor: usize`, `scroll_offset: usize`, `bytes_per_row: usize`, `visible_rows: usize`, `status_message: Option<String>`, `xor_view: bool`. |
 | `DiffStats` | `pub struct DiffStats` | Summary statistics for a diff. Fields: `total_bytes: usize`, `diff_count: usize`, `match_percentage: f64`, `first_diff: Option<usize>`, `left_size: usize`, `right_size: usize`. |
-| `DiffState::open` | `pub fn open(left_path: &str, right_path: &str) -> anyhow::Result<Self>` | Opens two files, reads them into memory, computes diff offsets, and returns an initialized `DiffState` with default cursor/scroll/view settings. |
-| `DiffState::max_len` | `pub fn max_len(&self) -> usize` | Returns the maximum length across both files. |
-| `DiffState::stats` | `pub fn stats(&self) -> DiffStats` | Computes and returns summary statistics including match percentage, diff count, and first diff offset. |
-| `DiffState::cursor_row` | `pub fn cursor_row(&self) -> usize` | Returns the row index for the current cursor position (`cursor / bytes_per_row`). |
-| `DiffState::ensure_cursor_visible` | `pub fn ensure_cursor_visible(&mut self)` | Adjusts `scroll_offset` so the cursor's row is within the visible window. |
-| `DiffState::move_cursor` | `pub fn move_cursor(&mut self, offset: isize)` | Moves cursor by a signed offset, clamped to `[0, max_len - 1]`. Calls `ensure_cursor_visible`. |
-| `DiffState::move_cursor_to` | `pub fn move_cursor_to(&mut self, pos: usize)` | Sets cursor to an absolute position, clamped to `[0, max_len - 1]`. Calls `ensure_cursor_visible`. |
-| `DiffState::page_down` | `pub fn page_down(&mut self)` | Moves cursor forward by `visible_rows * bytes_per_row` bytes. |
-| `DiffState::page_up` | `pub fn page_up(&mut self)` | Moves cursor backward by `visible_rows * bytes_per_row` bytes. |
-| `DiffState::next_diff` | `pub fn next_diff(&mut self)` | Jumps cursor to the next difference after the current position. Wraps to the first difference if at the end. Sets `status_message` with diff index info. |
-| `DiffState::prev_diff` | `pub fn prev_diff(&mut self)` | Jumps cursor to the previous difference before the current position. Wraps to the last difference if at the beginning. Sets `status_message` with diff index info. |
-| `DiffState::toggle_xor_view` | `pub fn toggle_xor_view(&mut self)` | Toggles `xor_view` and sets a status message indicating the new state. |
-| `DiffState::left_byte` | `pub fn left_byte(&self, offset: usize) -> Option<u8>` | Returns the byte at the given offset in the left file, or `None` if beyond its length. |
-| `DiffState::right_byte` | `pub fn right_byte(&self, offset: usize) -> Option<u8>` | Returns the byte at the given offset in the right file, or `None` if beyond its length. |
-| `DiffState::is_diff` | `pub fn is_diff(&self, offset: usize) -> bool` | Returns true if the given offset is in the diff offsets list (binary search). |
+| `open` | `pub fn open(left_path: &str, right_path: &str) -> anyhow::Result<Self>` | Opens two files, reads them into memory, computes diff offsets, and returns an initialized `DiffState` with default cursor/scroll/view settings. |
+| `max_len` | `pub fn max_len(&self) -> usize` | Returns the maximum length across both files. |
+| `stats` | `pub fn stats(&self) -> DiffStats` | Computes and returns summary statistics including match percentage, diff count, and first diff offset. |
+| `cursor_row` | `pub fn cursor_row(&self) -> usize` | Returns the row index for the current cursor position (`cursor / bytes_per_row`). |
+| `ensure_cursor_visible` | `pub fn ensure_cursor_visible(&mut self)` | Adjusts `scroll_offset` so the cursor's row is within the visible window. |
+| `move_cursor` | `pub fn move_cursor(&mut self, offset: isize)` | Moves cursor by a signed offset, clamped to `[0, max_len - 1]`. Calls `ensure_cursor_visible`. |
+| `move_cursor_to` | `pub fn move_cursor_to(&mut self, pos: usize)` | Sets cursor to an absolute position, clamped to `[0, max_len - 1]`. Calls `ensure_cursor_visible`. |
+| `page_down` | `pub fn page_down(&mut self)` | Moves cursor forward by `visible_rows * bytes_per_row` bytes. |
+| `page_up` | `pub fn page_up(&mut self)` | Moves cursor backward by `visible_rows * bytes_per_row` bytes. |
+| `next_diff` | `pub fn next_diff(&mut self)` | Jumps cursor to the next difference after the current position. Wraps to the first difference if at the end. Sets `status_message` with diff index info. |
+| `prev_diff` | `pub fn prev_diff(&mut self)` | Jumps cursor to the previous difference before the current position. Wraps to the last difference if at the beginning. Sets `status_message` with diff index info. |
+| `toggle_xor_view` | `pub fn toggle_xor_view(&mut self)` | Toggles `xor_view` and sets a status message indicating the new state. |
+| `left_byte` | `pub fn left_byte(&self, offset: usize) -> Option<u8>` | Returns the byte at the given offset in the left file, or `None` if beyond its length. |
+| `right_byte` | `pub fn right_byte(&self, offset: usize) -> Option<u8>` | Returns the byte at the given offset in the right file, or `None` if beyond its length. |
+| `is_diff` | `pub fn is_diff(&self, offset: usize) -> bool` | Returns true if the given offset is in the diff offsets list (binary search). |
 
 ## Invariants
 

--- a/specs/diff/requirements.md
+++ b/specs/diff/requirements.md
@@ -1,0 +1,24 @@
+---
+spec: diff.spec.md
+---
+
+## User Stories
+
+- As a user, I want to compare two binary files byte-by-byte so that I can identify exactly where they differ
+- As a user, I want to navigate between differences so that I can quickly jump to the next or previous change
+
+## Acceptance Criteria
+
+- Both files are loaded and compared byte-by-byte, producing a sorted list of differing offsets
+- Navigation between diffs supports forward and backward traversal with wraparound
+- Diff count and current position are tracked for display in the UI
+- Files of different lengths correctly report differences in the trailing region
+
+## Constraints
+
+- Both files must fit in memory (no streaming diff)
+
+## Out of Scope
+
+- Structural or semantic diffing (e.g., ELF section comparison)
+- Three-way merge

--- a/specs/diff/tasks.md
+++ b/specs/diff/tasks.md
@@ -1,0 +1,21 @@
+---
+spec: diff.spec.md
+---
+
+## Tasks
+
+- [x] Load two files and compare byte-by-byte
+- [x] Produce sorted list of differing offsets
+- [x] Next/previous diff navigation with wraparound
+- [x] Handle files of different lengths
+
+## Gaps
+
+<!-- Uncovered areas, missing edge cases, or incomplete coverage -->
+
+## Review Sign-offs
+
+- **Product**: pending
+- **QA**: pending
+- **Design**: n/a
+- **Dev**: pending

--- a/specs/diff_render/context.md
+++ b/specs/diff_render/context.md
@@ -1,0 +1,21 @@
+---
+spec: diff_render.spec.md
+---
+
+## Key Decisions
+
+<!-- Record architectural or design decisions relevant to this spec -->
+
+## Files to Read First
+
+- `src/diff_render.rs` — Diff view rendering logic
+
+## Current Status
+
+- Split-pane diff rendering implemented
+- XOR view mode working
+- Launched in v0.2.0
+
+## Notes
+
+<!-- Free-form notes, links, or context -->

--- a/specs/diff_render/context.md
+++ b/specs/diff_render/context.md
@@ -4,18 +4,21 @@ spec: diff_render.spec.md
 
 ## Key Decisions
 
-<!-- Record architectural or design decisions relevant to this spec -->
+- Layout-driven: Ratatui constraints split screen into header, stats bar, dual-panel split view, and status bar.
+- Dynamic bytes-per-row: auto-fitted via `(half_width - 10) / 3`.
+- Hierarchical styling: cursor (inverted white) > diff highlight (red) > additions (green bold) > semantic byte color (null/printable/control).
+- XOR mode renders XOR of left/right bytes on-the-fly in the right panel.
+- Stateless `draw_diff()` function — no cached render output, full redraw per frame.
 
 ## Files to Read First
 
-- `src/diff_render.rs` — Diff view rendering logic
+- `src/diff_render.rs` — all diff view rendering, color logic, layout
 
 ## Current Status
 
-- Split-pane diff rendering implemented
-- XOR view mode working
-- Launched in v0.2.0
+Complete. Split-pane rendering, XOR view, dynamic layout, and color-coded byte categories all working. Launched in v0.2.0.
 
 ## Notes
 
-<!-- Free-form notes, links, or context -->
+- `byte_color()` classifies bytes: null (dark gray), printable ASCII (cyan), control (yellow).
+- Status bar uses three-part layout: mode label, centered message, right-aligned hex address.

--- a/specs/diff_render/diff_render.spec.md
+++ b/specs/diff_render/diff_render.spec.md
@@ -6,7 +6,7 @@ files:
   - src/diff_render.rs
 db_tables: []
 depends_on:
-  - diff
+  - specs/diff/diff.spec.md
 ---
 
 ## Purpose

--- a/specs/diff_render/requirements.md
+++ b/specs/diff_render/requirements.md
@@ -1,0 +1,27 @@
+---
+spec: diff_render.spec.md
+---
+
+## User Stories
+
+- As a user, I want a side-by-side diff view so that I can visually compare two binary files
+- As a user, I want differing bytes highlighted so that changes are immediately visible
+- As a user, I want an XOR view option so that I can see the bitwise difference between files
+
+## Acceptance Criteria
+
+- Split-pane layout renders left file on left and right file (or XOR) on right
+- Vertical separator line clearly divides the two panes
+- Header bar shows filenames and diff statistics
+- Differing bytes are color-highlighted in both hex and ASCII columns
+- Status bar shows navigation position and diff count
+
+## Constraints
+
+- Must render within a single terminal frame without flicker
+- Layout must adapt to terminal width
+
+## Out of Scope
+
+- Resizable pane ratios
+- Inline patch editing from diff view

--- a/specs/diff_render/tasks.md
+++ b/specs/diff_render/tasks.md
@@ -1,0 +1,22 @@
+---
+spec: diff_render.spec.md
+---
+
+## Tasks
+
+- [x] Split-pane layout with vertical separator
+- [x] Header bar with filenames and diff stats
+- [x] Color-highlighted differing bytes
+- [x] XOR view mode
+- [x] Status bar with navigation position
+
+## Gaps
+
+<!-- Uncovered areas, missing edge cases, or incomplete coverage -->
+
+## Review Sign-offs
+
+- **Product**: pending
+- **QA**: pending
+- **Design**: n/a
+- **Dev**: pending

--- a/specs/entropy/context.md
+++ b/specs/entropy/context.md
@@ -4,18 +4,21 @@ spec: entropy.spec.md
 
 ## Key Decisions
 
-<!-- Record architectural or design decisions relevant to this spec -->
+- Frequency table approach: pre-allocated `[u32; 256]` array rather than HashMap — O(1) lookup, cache-friendly.
+- Shannon entropy formula: `-Σ(p_i * log₂(p_i))` yielding [0.0, 8.0] bits per byte.
+- Window-based analysis: sliding window computes per-window entropy; range queries average over overlapping windows.
+- Color gradient: entropy → smooth RGB via four-segment piecewise interpolation (blue → cyan → yellow → red).
+- Accepts generic `Buffer` trait rather than raw slices for reuse across data sources.
 
 ## Files to Read First
 
-- `src/entropy.rs` — Entropy calculation and color mapping
+- `src/entropy.rs` — entropy calculation, window analysis, color mapping
 
 ## Current Status
 
-- Shannon entropy calculation implemented
-- Color gradient heatmap visualization working
-- Launched in v0.2.0
+Complete. Global, per-window, and range-averaged entropy calculations all working. Heatmap color gradient rendering integrated. Launched in v0.2.0.
 
 ## Notes
 
-<!-- Free-form notes, links, or context -->
+- No caching — recalculates on demand (suitable for small/medium files).
+- Tests validate mathematical properties: uniform distribution = 8.0 bits, single byte = 0.0, two equal values = 1.0 bit.

--- a/specs/entropy/context.md
+++ b/specs/entropy/context.md
@@ -1,0 +1,21 @@
+---
+spec: entropy.spec.md
+---
+
+## Key Decisions
+
+<!-- Record architectural or design decisions relevant to this spec -->
+
+## Files to Read First
+
+- `src/entropy.rs` — Entropy calculation and color mapping
+
+## Current Status
+
+- Shannon entropy calculation implemented
+- Color gradient heatmap visualization working
+- Launched in v0.2.0
+
+## Notes
+
+<!-- Free-form notes, links, or context -->

--- a/specs/entropy/requirements.md
+++ b/specs/entropy/requirements.md
@@ -1,0 +1,24 @@
+---
+spec: entropy.spec.md
+---
+
+## User Stories
+
+- As a user, I want to see an entropy heatmap so that I can identify compressed, encrypted, or structured regions in a binary file
+- As a user, I want entropy calculated per-window so that the visualization has meaningful granularity
+
+## Acceptance Criteria
+
+- Shannon entropy is computed per configurable window size across the file
+- Entropy values are mapped to a color gradient (low entropy = cool, high = warm)
+- Average entropy can be computed over arbitrary byte ranges for the inspector
+- Heatmap renders as a visual bar alongside the hex view
+
+## Constraints
+
+- Entropy calculation must be fast enough to not block the UI on large files
+
+## Out of Scope
+
+- Alternative entropy algorithms (e.g., min-entropy, Renyi entropy)
+- Per-byte entropy (window-based only)

--- a/specs/entropy/tasks.md
+++ b/specs/entropy/tasks.md
@@ -1,0 +1,21 @@
+---
+spec: entropy.spec.md
+---
+
+## Tasks
+
+- [x] Per-window Shannon entropy calculation
+- [x] Entropy-to-color gradient mapping
+- [x] Average entropy over arbitrary byte ranges
+- [x] Heatmap bar rendering
+
+## Gaps
+
+<!-- Uncovered areas, missing edge cases, or incomplete coverage -->
+
+## Review Sign-offs
+
+- **Product**: pending
+- **QA**: pending
+- **Design**: n/a
+- **Dev**: pending

--- a/specs/format/context.md
+++ b/specs/format/context.md
@@ -1,0 +1,15 @@
+---
+spec: format.spec.md
+---
+
+## Key Decisions
+
+- Magic-byte detection with optional secondary magic: some formats (e.g. WAV with RIFF+WAVE headers) need two checks at different offsets.
+- Dynamic chunk resolution for container formats: PNG and ZIP have variable-length records that are walked at runtime rather than statically defined.
+- First-wins semantics in `build_field_map`: when fields overlap, the first field in template order claims contested byte offsets.
+- TOML custom templates use a `serde::Deserialize` intermediate struct (`TomlTemplate`/`TomlField`) that maps to the internal types.
+- `load_custom_templates` uses silent error handling — unparseable files are skipped so one bad template doesn't break the entire system.
+
+## Files to Read First
+
+- `src/format.rs` — complete module: field types, template struct, built-in definitions, magic detection, TOML parsing, PNG/ZIP chunk walking

--- a/specs/format/format.spec.md
+++ b/specs/format/format.spec.md
@@ -17,12 +17,12 @@ Provides a template system for parsing and labeling known binary file formats. T
 | Symbol | Signature | Description |
 |--------|-----------|-------------|
 | `FieldType` | `pub enum FieldType` | How a template field's bytes are interpreted. Variants: `U8`, `U16Le`, `U16Be`, `U32Le`, `U32Be`, `U64Le`, `U64Be`, `AsciiStr`, `Bytes`. |
-| `FieldType::from_str` | `pub fn from_str(s: &str) -> Self` | Parses a field type string (e.g. `"u16le"`, `"ascii"`) into a `FieldType`. Case-insensitive. Unknown strings default to `Bytes`. |
+| `from_str` | `pub fn from_str(s: &str) -> Self` | Parses a field type string (e.g. `"u16le"`, `"ascii"`) into a `FieldType`. Case-insensitive. Unknown strings default to `Bytes`. |
 | `TemplateField` | `pub struct TemplateField` | A single named field: `name`, `offset`, `size`, `field_type`. |
 | `parse_field_value` | `pub fn parse_field_value(field: &TemplateField, bytes: &[u8]) -> String` | Formats a field's bytes as a human-readable string based on its `FieldType`. Returns `"(out of range)"` if bytes are too short. |
 | `FormatTemplate` | `pub struct FormatTemplate` | A complete format template: `name`, `magic`, `magic_offset`, `second_magic`, `fields`. |
-| `FormatTemplate::matches` | `pub fn matches(&self, data: &[u8]) -> bool` | Checks if data matches this template's magic bytes (and optional secondary magic). |
-| `FormatTemplate::resolve_fields` | `pub fn resolve_fields(&self, data: &[u8]) -> Vec<TemplateField>` | Returns static fields plus dynamically resolved chunk fields (PNG chunks, ZIP entries). |
+| `matches` | `pub fn matches(&self, data: &[u8]) -> bool` | Checks if data matches this template's magic bytes (and optional secondary magic). |
+| `resolve_fields` | `pub fn resolve_fields(&self, data: &[u8]) -> Vec<TemplateField>` | Returns static fields plus dynamically resolved chunk fields (PNG chunks, ZIP entries). |
 | `build_field_map` | `pub fn build_field_map(fields: &[TemplateField]) -> HashMap<usize, (String, usize)>` | Builds a byte-offset to (field_name, field_index) lookup map covering every byte within each field's range. |
 | `builtin_templates` | `pub fn builtin_templates() -> Vec<FormatTemplate>` | Returns all built-in format templates (PNG, ZIP, ELF, PE, Mach-O, SQLite, JPEG, GIF, BMP, WAV, PDF). |
 | `detect_format` | `pub fn detect_format(data: &[u8], extra: &[FormatTemplate]) -> Option<FormatTemplate>` | Auto-detects a file's format by trying each template's magic bytes. Checks user-provided templates first, then built-ins. |

--- a/specs/format/format.spec.md
+++ b/specs/format/format.spec.md
@@ -1,0 +1,85 @@
+---
+module: format
+version: 1
+status: draft
+files:
+  - src/format.rs
+db_tables: []
+depends_on: []
+---
+
+## Purpose
+
+Provides a template system for parsing and labeling known binary file formats. Templates define named fields at specific byte offsets with typed interpretation (integers of various widths/endianness, ASCII strings, raw bytes). Ships with built-in templates for common formats (PNG, ZIP, ELF, PE, Mach-O, SQLite, JPEG, GIF, BMP, WAV, PDF) and supports user-defined TOML templates loaded from `~/.config/chx/templates/`.
+
+## Public API
+
+| Symbol | Signature | Description |
+|--------|-----------|-------------|
+| `FieldType` | `pub enum FieldType` | How a template field's bytes are interpreted. Variants: `U8`, `U16Le`, `U16Be`, `U32Le`, `U32Be`, `U64Le`, `U64Be`, `AsciiStr`, `Bytes`. |
+| `FieldType::from_str` | `pub fn from_str(s: &str) -> Self` | Parses a field type string (e.g. `"u16le"`, `"ascii"`) into a `FieldType`. Case-insensitive. Unknown strings default to `Bytes`. |
+| `TemplateField` | `pub struct TemplateField` | A single named field: `name`, `offset`, `size`, `field_type`. |
+| `parse_field_value` | `pub fn parse_field_value(field: &TemplateField, bytes: &[u8]) -> String` | Formats a field's bytes as a human-readable string based on its `FieldType`. Returns `"(out of range)"` if bytes are too short. |
+| `FormatTemplate` | `pub struct FormatTemplate` | A complete format template: `name`, `magic`, `magic_offset`, `second_magic`, `fields`. |
+| `FormatTemplate::matches` | `pub fn matches(&self, data: &[u8]) -> bool` | Checks if data matches this template's magic bytes (and optional secondary magic). |
+| `FormatTemplate::resolve_fields` | `pub fn resolve_fields(&self, data: &[u8]) -> Vec<TemplateField>` | Returns static fields plus dynamically resolved chunk fields (PNG chunks, ZIP entries). |
+| `build_field_map` | `pub fn build_field_map(fields: &[TemplateField]) -> HashMap<usize, (String, usize)>` | Builds a byte-offset to (field_name, field_index) lookup map covering every byte within each field's range. |
+| `builtin_templates` | `pub fn builtin_templates() -> Vec<FormatTemplate>` | Returns all built-in format templates (PNG, ZIP, ELF, PE, Mach-O, SQLite, JPEG, GIF, BMP, WAV, PDF). |
+| `detect_format` | `pub fn detect_format(data: &[u8], extra: &[FormatTemplate]) -> Option<FormatTemplate>` | Auto-detects a file's format by trying each template's magic bytes. Checks user-provided templates first, then built-ins. |
+| `parse_toml_template` | `pub fn parse_toml_template(toml_str: &str) -> Result<FormatTemplate, String>` | Parses a TOML string into a `FormatTemplate`. |
+| `load_custom_templates` | `pub fn load_custom_templates() -> Vec<FormatTemplate>` | Loads all `.toml` files from `~/.config/chx/templates/` as custom format templates. Silently skips unparseable files. |
+
+## Invariants
+
+1. `FieldType::from_str` is case-insensitive and defaults to `Bytes` for unknown strings.
+2. `FormatTemplate::matches` returns false if magic bytes are empty or data is too short.
+3. Secondary magic check is only performed if primary magic matches first.
+4. `resolve_fields` only performs dynamic chunk resolution for "PNG Image" and "ZIP Archive" templates; all others return static fields only.
+5. `build_field_map` uses first-wins semantics: if fields overlap at a byte offset, the first field in the list claims that offset.
+6. `detect_format` checks user-provided (`extra`) templates before built-ins, allowing user overrides.
+7. PNG chunk resolution walks chunks sequentially from offset 8 and stops when data is exhausted or a chunk would exceed bounds.
+8. ZIP entry resolution walks local file headers starting at offset 0, stopping when the magic `PK\x03\x04` is not found.
+9. Custom TOML templates require `name`, `magic`, and `magic_offset` fields; `fields` array and `second_magic` are optional.
+10. `load_custom_templates` reads from `~/.config/chx/templates/` and silently ignores files that fail to parse.
+
+## Behavioral Examples
+
+**Auto-detect PNG**
+- Given: data starts with `[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]`
+- When: `detect_format(data, &[])` is called
+- Then: returns the PNG template with IHDR fields and dynamic chunk resolution
+
+**Parse u16le field**
+- Given: a `TemplateField` with `field_type: U16Le`, `size: 2`, and bytes `[0x01, 0x00]`
+- When: `parse_field_value` is called
+- Then: returns `"1 (0x0001)"`
+
+**Custom template override**
+- Given: a custom template with the same magic as PNG is passed in `extra`
+- When: `detect_format` is called on PNG data
+- Then: returns the custom template (checked before built-ins)
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Data shorter than magic offset + magic length | `matches` returns false |
+| Field bytes shorter than field size | `parse_field_value` returns `"(out of range)"` |
+| Invalid TOML in custom template file | `parse_toml_template` returns `Err`; `load_custom_templates` skips the file |
+| `~/.config/chx/templates/` directory doesn't exist | `load_custom_templates` returns empty vec |
+| Empty magic bytes in template | `matches` always returns false |
+
+## Dependencies
+
+| Dependency | Usage |
+|------------|-------|
+| `serde` | `Deserialize` derive for TOML parsing helper structs |
+| `toml` | Parsing custom TOML template files |
+| `std::collections::HashMap` | `build_field_map` offset lookup |
+| `std::fs` / `std::path` | Reading custom template files from disk |
+
+## Change Log
+
+| Date | Description |
+|------|-------------|
+| 2026-03-30 | Initial spec for format template system |

--- a/specs/format/requirements.md
+++ b/specs/format/requirements.md
@@ -1,0 +1,18 @@
+---
+spec: format.spec.md
+---
+
+## User Stories
+
+- As a user, I want common binary formats auto-detected so that I can see labeled fields without manual setup
+- As a user, I want to define custom TOML templates so that I can label proprietary or uncommon formats
+- As a user, I want field values decoded with proper endianness so that I can read integer and string values in context
+
+## Acceptance Criteria
+
+- Built-in templates cover PNG, ZIP, ELF, PE, Mach-O, SQLite, JPEG, GIF, BMP, WAV, PDF
+- Format detection tries user templates before built-ins, allowing overrides
+- PNG and ZIP templates dynamically resolve chunk/entry fields beyond static headers
+- Custom templates are loaded from `~/.config/chx/templates/` as TOML files
+- Invalid custom templates are silently skipped without crashing
+- Field types support u8, u16/u32/u64 in both endianness, ASCII strings, and raw bytes

--- a/specs/input/context.md
+++ b/specs/input/context.md
@@ -4,16 +4,21 @@ spec: input.spec.md
 
 ## Key Decisions
 
-<!-- Record architectural or design decisions relevant to this spec -->
+- Mode-based dispatch: `handle_key()` routes to mode-specific handlers (normal, edit_hex, edit_ascii, command, search, visual, strings, inspector, inspector_edit).
+- Hex nibble buffering: EditHex stores partial nibble in `app.hex_nibble: Option<u8>`, writes on full byte (high+low). Navigation resets the nibble.
+- Pending bookmark operations: two-key sequences (`m`+letter for set, `'`+letter for jump) handled via `app.pending_bookmark` field.
+- Mouse support: clicks (positioning + mode exit), drags (visual selection), scroll wheel (3-row movement).
+- Tab toggles between EditHex and EditAscii, resetting `hex_nibble` when entering EditHex.
 
 ## Files to Read First
 
-<!-- List the most important files an agent or new developer should read -->
+- `src/input.rs` — all input handling (1000+ lines, mode dispatch is the entry point)
 
 ## Current Status
 
-<!-- What's done, what's in progress, what's blocked -->
+Complete. All modes implemented: normal, visual, edit (hex/ascii), command, search, strings, inspector, inspector_edit. Bookmarks, mouse, undo/redo, copy/paste all working.
 
 ## Notes
 
-<!-- Free-form notes, links, or context -->
+- Command mode (`:`) handles save, quit, goto, set bytes-per-row, and template commands.
+- Search mode delegates to `search.rs` for pattern parsing and result navigation.

--- a/specs/input/requirements.md
+++ b/specs/input/requirements.md
@@ -1,0 +1,27 @@
+---
+spec: input.spec.md
+---
+
+## User Stories
+
+- As a user, I want keyboard shortcuts to work consistently across modes so that I can build muscle memory
+- As a user, I want mouse support for clicking on bytes and scrolling so that I can navigate intuitively
+
+## Acceptance Criteria
+
+- All key events are dispatched to the correct mode-specific handler
+- Normal mode supports vim-style navigation (h/j/k/l, g/G, Ctrl-d/u)
+- Edit modes (hex/ascii) correctly handle character input and cursor movement
+- Command and search modes handle text input with backspace and enter
+- Mouse clicks translate to cursor position changes
+- Mouse scroll translates to vertical scrolling
+
+## Constraints
+
+- Input handling must be non-blocking to keep the event loop responsive
+- Crossterm key event model is the source of truth for key representation
+
+## Out of Scope
+
+- User-configurable keybindings
+- Macro recording and playback

--- a/specs/inspector/requirements.md
+++ b/specs/inspector/requirements.md
@@ -1,0 +1,25 @@
+---
+spec: inspector.spec.md
+---
+
+## User Stories
+
+- As a user, I want to see the bytes at my cursor interpreted as various data types so that I can understand the data without manual conversion
+- As a user, I want both little-endian and big-endian interpretations so that I can work with files from different architectures
+
+## Acceptance Criteria
+
+- Displays u8, i8, binary, octal, ASCII, and UTF-8 interpretations of the byte at cursor
+- Displays u16/i16/u32/i32/f32/u64/i64/f64 in both little-endian and big-endian
+- Gracefully handles insufficient bytes (e.g., cursor near end of file)
+- Inspector panel updates live as cursor moves
+- Editable fields allow modifying values and writing back to the buffer
+
+## Constraints
+
+- Must handle all standard IEEE 754 float edge cases (NaN, Inf, denormals)
+
+## Out of Scope
+
+- Custom/user-defined type interpretations
+- Struct-level parsing (that's the format template system)

--- a/specs/render/context.md
+++ b/specs/render/context.md
@@ -4,16 +4,21 @@ spec: render.spec.md
 
 ## Key Decisions
 
-<!-- Record architectural or design decisions relevant to this spec -->
+- Strict color priority: cursor > search hit > modification/category color. Enforced identically in hex and ASCII columns.
+- Dynamic bytes-per-row: auto-fit to terminal width via `max_bpr = (width - 14) / 4`. User-requested value clamped to available space.
+- Visible rows recalculated per frame: `terminal_height - 3` (header + status + margin), clamped via saturating subtraction.
+- Template field overlay uses cyclic palette (8 alternating fg/bg pairs) when `app.show_template_overlay` is true.
+- Inspector panel rendered as optional right column showing field interpretations (u8/u16/u32/u64 in LE/BE).
 
 ## Files to Read First
 
-<!-- List the most important files an agent or new developer should read -->
+- `src/render.rs` — all UI rendering (600+ lines)
 
 ## Current Status
 
-<!-- What's done, what's in progress, what's blocked -->
+Complete. Renders header (with dirty marker), hex/ASCII grid with proper spacing, cursor/search/selection highlighting, status bar, and optional panels (inspector, entropy, strings).
 
 ## Notes
 
-<!-- Free-form notes, links, or context -->
+- Entropy and strings panels are optional left/bottom overlays toggled by the user.
+- The render module is purely presentational — all state lives in `App`.

--- a/specs/render/requirements.md
+++ b/specs/render/requirements.md
@@ -1,0 +1,29 @@
+---
+spec: render.spec.md
+---
+
+## User Stories
+
+- As a user, I want a clear hex/ASCII split view so that I can read binary data efficiently
+- As a user, I want the current byte highlighted and the view to scroll with my cursor so that I never lose my position
+- As a user, I want a status bar showing mode, offset, and file info so that I always know where I am
+
+## Acceptance Criteria
+
+- Full-screen layout with header, hex/ASCII view, optional inspector panel, and status bar
+- Hex view shows offset column, hex bytes, and ASCII representation per row
+- Cursor position is highlighted in both hex and ASCII columns
+- View scrolls to keep cursor visible at all times
+- Visual selection is rendered with distinct highlighting
+- Modified bytes are visually distinct from unmodified bytes
+- Status bar shows current mode, cursor offset, file size, and dirty state
+
+## Constraints
+
+- Must render full frame within a single terminal flush to avoid flicker
+- Layout must adapt to terminal resize events
+
+## Out of Scope
+
+- Theming or color customization
+- Split-pane views (diff_render handles that)

--- a/specs/search/context.md
+++ b/specs/search/context.md
@@ -4,16 +4,21 @@ spec: search.spec.md
 
 ## Key Decisions
 
-<!-- Record architectural or design decisions relevant to this spec -->
+- Pattern parsing: `x/` or `0x` prefix triggers hex mode; otherwise ASCII. Hex patterns require even digit count after stripping whitespace.
+- Case-insensitive flag: `/i` suffix enables `eq_ignore_ascii_case` for ASCII patterns only (not hex).
+- Incremental search: separate function updates results without clearing input or moving cursor — used for live highlighting as user types.
+- Pattern length stored in `app.search_pattern_len` so render can highlight the full match span.
+- Wrapping navigation: `next_search_result` and `prev_search_result` use modulo arithmetic to wrap around.
+- Find-and-replace constrained to same-length patterns (overwrite mode only).
 
 ## Files to Read First
 
-<!-- List the most important files an agent or new developer should read -->
+- `src/search.rs` — all search logic (pattern parsing, execution, navigation, find-replace)
 
 ## Current Status
 
-<!-- What's done, what's in progress, what's blocked -->
+Complete. ASCII/hex pattern parsing, case-insensitive flag, incremental search, full-span highlighting, wrapping navigation, and find-and-replace all implemented and tested.
 
 ## Notes
 
-<!-- Free-form notes, links, or context -->
+- Search results are stored as a sorted `Vec<usize>` of offsets. Binary search used for navigation.

--- a/specs/search/requirements.md
+++ b/specs/search/requirements.md
@@ -1,0 +1,26 @@
+---
+spec: search.spec.md
+---
+
+## User Stories
+
+- As a user, I want to search for ASCII strings in a binary file so that I can find text content
+- As a user, I want to search for hex byte patterns so that I can locate specific byte sequences
+- As a user, I want to navigate between search results so that I can examine each match
+
+## Acceptance Criteria
+
+- Search supports ASCII string queries and hex byte patterns (e.g., `FF D8 FF`)
+- Case-insensitive search is available for ASCII queries
+- All matches in the buffer are found and navigable with next/previous
+- Search results update the cursor position and scroll the view to the match
+- Invalid hex patterns produce a clear error message
+
+## Constraints
+
+- Full-buffer search must complete fast enough to feel interactive on typical files
+
+## Out of Scope
+
+- Regex search
+- Search and replace (edit mode handles byte modification)


### PR DESCRIPTION
## Summary

- Bump GitHub Action to `CorvidLabs/spec-sync@v3` (pinned to v3.2.0)
- Add `AGENTS.md` with spec-sync integration instructions (v3.1.0 hook target)
- Add `requirements.md` companion files for all 9 modules with user stories, acceptance criteria, constraints, and out-of-scope sections
- Add missing `context.md` and `tasks.md` for diff, diff_render, and entropy modules
- Populate all 9 `context.md` files with real architectural context (key decisions, important files, current status)

Aligns with spec-sync v3.2.0: plain-bullet acceptance criteria (not checkboxes), companion file context in agent hooks.

## Test plan

- [ ] CI passes with the updated `@v3` action
- [ ] All 9 modules have the full companion file set: `spec.md`, `tasks.md`, `context.md`, `requirements.md`
- [ ] `specsync check --strict` passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)