### PR TITLE
CI: standardize Actions (paths + concurrency + runners)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,36 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/ci.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/ci.yml"
 
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,11 @@ name: Deploy Rust Docs
 on:
   push:
     branches: [main]
+    paths:
+      - "src/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 permissions:
@@ -17,8 +22,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: Build docs
         run: cargo doc --no-deps --document-private-items
@@ -33,6 +39,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/spec-check.yml
+++ b/.github/workflows/spec-check.yml
@@ -1,15 +1,35 @@
 name: Spec Validation
-on: [push, pull_request]
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "specs/**"
+      - "src/**"
+      - "specsync.json"
+      - ".github/workflows/spec-check.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "specs/**"
+      - "src/**"
+      - "specsync.json"
+      - ".github/workflows/spec-check.yml"
 
 permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: spec-check-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   specsync:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: CorvidLabs/spec-sync@v3.2.0
         with:
           strict: 'true'

--- a/src/input.rs
+++ b/src/input.rs
@@ -220,11 +220,9 @@ fn handle_normal(app: &mut App, key: KeyEvent) -> bool {
         }
 
         // Tab focuses the inspector panel if visible
-        KeyCode::Tab => {
-            if app.inspector_visible {
-                app.mode = Mode::Inspector;
-                app.status_message = None;
-            }
+        KeyCode::Tab if app.inspector_visible => {
+            app.mode = Mode::Inspector;
+            app.status_message = None;
         }
 
         _ => {}
@@ -964,7 +962,7 @@ mod tests {
     }
 
     #[test]
-    fn visual_mode_home_end_g_G() {
+    fn visual_mode_home_end_g_shift_g() {
         let mut app = make_app(&vec![0u8; 256]);
         app.cursor = 5;
         handle_key(&mut app, key(KeyCode::Char('v')));


### PR DESCRIPTION
Standardizes GitHub Actions for this PUBLIC Rust/Cargo crate (`chx`, a TUI hex editor) to the CorvidLabs CI standard.

## Changes
- **ci.yml**: scoped `push`/`pull_request` to `main` with a rust-cargo `paths:` set (`src/**`, `tests/**`, `Cargo.toml`, `Cargo.lock`, + this workflow); added `concurrency` group with `cancel-in-progress`; bumped `actions/checkout@v5`; added `timeout-minutes`. Preserved clippy + `cargo test` logic.
- **spec-check.yml**: scoped triggers to spec-relevant paths (`specs/**`, `src/**`, `specsync.json`, + this workflow); added `concurrency`; `checkout@v5`; `timeout-minutes`. Preserved spec-sync action.
- **docs.yml** (pages/deploy): scoped `push` `paths:` to doc source (`src/**`, `Cargo.toml`, `Cargo.lock`, + this workflow); kept existing `group: pages` concurrency (`cancel-in-progress: false` is correct for deploys); `checkout@v5`; `timeout-minutes`.
- **release.yml**: unchanged — tag-push triggered, GitHub-hosted matrix runners already correct for a public repo (no `paths:`/concurrency required).

## Runners
All jobs stay on GitHub-hosted `ubuntu-latest` (public repo — never self-hosted).

Validated with `python3 yaml.safe_load` and `actionlint` (all pass).

Mirrors the CorvidLabs/merlin CI standard.